### PR TITLE
progression bar

### DIFF
--- a/app/assets/stylesheets/challenges/_show.scss
+++ b/app/assets/stylesheets/challenges/_show.scss
@@ -34,7 +34,7 @@
 }
 
 .progress-bar-goal {
-  background-color: #115549;
+  background-color: #1155499e !important;
 }
 .progress-goal {
   --bs-progress-bar-color: #fff;


### PR DESCRIPTION
couleur changée :) comme ça ça n'a pas la meme teinte que le bouton majeur de la page !
<img width="297" alt="Capture d’écran 2022-12-08 à 17 02 17" src="https://user-images.githubusercontent.com/106176972/206497359-38cd6a66-a451-4d3f-b37c-ead487625266.png">
